### PR TITLE
update workflow to only backup to chart museum

### DIFF
--- a/.github/workflows/backup-and-mirror-charts.yaml
+++ b/.github/workflows/backup-and-mirror-charts.yaml
@@ -13,12 +13,29 @@ permissions:
   contents: write
 
 jobs:
+    # env context is not accessable in called workflow
+  # https://github.com/orgs/community/discussions/26671
+  # https://stackoverflow.com/questions/73305126/passing-env-variable-inputs-to-a-reusable-workflow
+  pass-env-var-to-workflow:
+    runs-on: ubuntu-latest
+    outputs:
+      registry-source: ${{ steps.step1.outputs.REGISTRY_SOURCE }}
+      registry-destination: ${{ steps.step2.outputs.REGISTRY_DESTINATION }}
+    steps:
+      - id: step1
+        run: echo "REGISTRY_SOURCE=${REGISTRY_SOURCE}" >> "$GITHUB_OUTPUT"
+      - id: step2 
+        run: echo "REGISTRY_DESTINATION=${REGISTRY_DESTINATION}" >> "$GITHUB_OUTPUT"
+
+
   download-charts:
     uses: konstructio/charts-mirror/.github/workflows/tpl-download-charts.yaml@mirror-only
+    needs: pass-env-var-to-workflow
     with:
-      registry-source: "${REGISTRY_SOURCE}"
+      registry-source: "${{ needs.pass-env-var-to-workflow.outputs.registry-source }}"
 
   mirror-charts:
     uses: konstructio/charts-mirror/.github/workflows/tpl-mirror-charts.yaml@mirror-only
+    needs: pass-env-var-to-workflow
     with:
-      registry-destination: "${REGISTRY_DESTINATION}"
+      registry-destination: "${{ needs.pass-env-var-to-workflow.outputs. registry-destination }}"

--- a/.github/workflows/backup-and-mirror-charts.yaml
+++ b/.github/workflows/backup-and-mirror-charts.yaml
@@ -1,0 +1,24 @@
+name: "Backup and then Mirror Helm Charts"
+
+on:
+  # push: # runs on any branch push
+  schedule:
+    - cron: "0 0 * * 1" # runs every Monday at midnight
+  workflow_dispatch: # runs whenever the workflow is dispatched via the UI
+
+env:
+  REGISTRY_SOURCE: "https://charts.konstruct.io/"
+
+permissions:
+  contents: write
+
+jobs:
+  download-charts:
+    uses: konstructio/charts-mirror/.github/workflows/tpl-download-charts.yaml@mirror-only
+    with:
+      registry-source: "${REGISTRY_SOURCE}"
+
+  mirror-charts:
+    uses: konstructio/charts-mirror/.github/workflows/tpl-mirror-charts.yaml@mirror-only
+    with:
+      registry-destination: "${REGISTRY_DESTINATION}"

--- a/.github/workflows/backup-and-mirror-charts.yaml
+++ b/.github/workflows/backup-and-mirror-charts.yaml
@@ -30,13 +30,13 @@ jobs:
 
 
   download-charts:
-    uses: konstructio/charts-mirror/.github/workflows/tpl-download-charts.yaml@mirror-only
+    uses: ./.github/workflows/tpl-download-charts.yaml
     needs: pass-env-var-to-workflow
     with:
       registry-source: "${{ needs.pass-env-var-to-workflow.outputs.registry-source }}"
 
   mirror-charts:
-    uses: konstructio/charts-mirror/.github/workflows/tpl-mirror-charts.yaml@mirror-only
+    uses: ./.github/workflows/tpl-mirror-charts.yaml
     needs: pass-env-var-to-workflow
     with:
       registry-destination: "${{ needs.pass-env-var-to-workflow.outputs.registry-destination }}"

--- a/.github/workflows/backup-and-mirror-charts.yaml
+++ b/.github/workflows/backup-and-mirror-charts.yaml
@@ -6,10 +6,6 @@ on:
   #   - cron: "0 0 * * 1" # runs every Monday at midnight
   workflow_dispatch: # runs whenever the workflow is dispatched via the UI
 
-env:
-  REGISTRY_SOURCE: "https://charts.konstruct.io/"
-  REGISTRY_DESTINATION: "https://charts.konstruct.io/"
-
 permissions:
   contents: write
 

--- a/.github/workflows/backup-and-mirror-charts.yaml
+++ b/.github/workflows/backup-and-mirror-charts.yaml
@@ -39,4 +39,4 @@ jobs:
     uses: konstructio/charts-mirror/.github/workflows/tpl-mirror-charts.yaml@mirror-only
     needs: pass-env-var-to-workflow
     with:
-      registry-destination: "${{ needs.pass-env-var-to-workflow.outputs. registry-destination }}"
+      registry-destination: "${{ needs.pass-env-var-to-workflow.outputs.registry-destination }}"

--- a/.github/workflows/backup-and-mirror-charts.yaml
+++ b/.github/workflows/backup-and-mirror-charts.yaml
@@ -8,6 +8,7 @@ on:
 
 env:
   REGISTRY_SOURCE: "https://charts.konstruct.io/"
+  REGISTRY_DESTINATION: "https://charts.konstruct.io/"
 
 permissions:
   contents: write

--- a/.github/workflows/backup-and-mirror-charts.yaml
+++ b/.github/workflows/backup-and-mirror-charts.yaml
@@ -23,3 +23,4 @@ jobs:
     uses: ./.github/workflows/tpl-mirror-charts.yaml
     with:
       registry-destination: "https://charts.konstruct.io/"
+    secrets: inherit

--- a/.github/workflows/backup-and-mirror-charts.yaml
+++ b/.github/workflows/backup-and-mirror-charts.yaml
@@ -14,29 +14,12 @@ permissions:
   contents: write
 
 jobs:
-    # env context is not accessable in called workflow
-  # https://github.com/orgs/community/discussions/26671
-  # https://stackoverflow.com/questions/73305126/passing-env-variable-inputs-to-a-reusable-workflow
-  pass-env-var-to-workflow:
-    runs-on: ubuntu-latest
-    outputs:
-      registry-source: ${{ steps.step1.outputs.REGISTRY_SOURCE }}
-      registry-destination: ${{ steps.step2.outputs.REGISTRY_DESTINATION }}
-    steps:
-      - id: step1
-        run: echo "REGISTRY_SOURCE=${REGISTRY_SOURCE}" >> "$GITHUB_OUTPUT"
-      - id: step2 
-        run: echo "REGISTRY_DESTINATION=${REGISTRY_DESTINATION}" >> "$GITHUB_OUTPUT"
-
-
   download-charts:
     uses: ./.github/workflows/tpl-download-charts.yaml
-    needs: pass-env-var-to-workflow
     with:
-      registry-source: "${{ needs.pass-env-var-to-workflow.outputs.registry-source }}"
+      registry-source: "https://charts.konstruct.io/"
 
   mirror-charts:
     uses: ./.github/workflows/tpl-mirror-charts.yaml
-    needs: pass-env-var-to-workflow
     with:
-      registry-destination: "${{ needs.pass-env-var-to-workflow.outputs.registry-destination }}"
+      registry-destination: "https://charts.konstruct.io/"

--- a/.github/workflows/backup-and-mirror-charts.yaml
+++ b/.github/workflows/backup-and-mirror-charts.yaml
@@ -2,8 +2,8 @@ name: "Backup and then Mirror Helm Charts"
 
 on:
   # push: # runs on any branch push
-  schedule:
-    - cron: "0 0 * * 1" # runs every Monday at midnight
+  # schedule:
+  #   - cron: "0 0 * * 1" # runs every Monday at midnight
   workflow_dispatch: # runs whenever the workflow is dispatched via the UI
 
 env:

--- a/.github/workflows/backup-charts.yaml
+++ b/.github/workflows/backup-charts.yaml
@@ -2,6 +2,8 @@ name: "Backup Helm Charts"
 
 on:
   push: # runs on any branch push
+  schedule:
+    - cron: "0 0 * * 1" # runs every Monday at midnight
   workflow_dispatch: # runs whenever the workflow is dispatched via the UI
 
 env:

--- a/.github/workflows/backup-charts.yaml
+++ b/.github/workflows/backup-charts.yaml
@@ -2,8 +2,6 @@ name: "Backup Helm Charts"
 
 on:
   push: # runs on any branch push
-  schedule:
-    - cron: "0 0 * * 1" # runs every Monday at midnight
   workflow_dispatch: # runs whenever the workflow is dispatched via the UI
 
 env:

--- a/.github/workflows/backup-charts.yaml
+++ b/.github/workflows/backup-charts.yaml
@@ -25,7 +25,7 @@ jobs:
         run: echo "REGISTRY_SOURCE=${REGISTRY_SOURCE}" >> "$GITHUB_OUTPUT"
 
   download-charts:
-    uses: konstructio/charts-mirror/.github/workflows/tpl-download-charts.yaml@mirror-only
+    uses: ./.github/workflows/tpl-download-charts.yaml
     needs: pass-env-var-to-workflow
     with:
       registry-source: "${{ needs.pass-env-var-to-workflow.outputs.registry-source }}"

--- a/.github/workflows/backup-charts.yaml
+++ b/.github/workflows/backup-charts.yaml
@@ -6,27 +6,11 @@ on:
     - cron: "0 0 * * 1" # runs every Monday at midnight
   workflow_dispatch: # runs whenever the workflow is dispatched via the UI
 
-env:
-  REGISTRY_SOURCE: "https://charts.konstruct.io/"
-
 permissions:
   contents: write
 
 jobs:
-  # env context is not accessable in called workflow
-  # https://github.com/orgs/community/discussions/26671
-  # https://stackoverflow.com/questions/73305126/passing-env-variable-inputs-to-a-reusable-workflow
-  pass-env-var-to-workflow:
-    runs-on: ubuntu-latest
-    outputs:
-      registry-source: ${{ steps.step1.outputs.REGISTRY_SOURCE }}
-    steps:
-      - id: step1
-        run: echo "REGISTRY_SOURCE=${REGISTRY_SOURCE}" >> "$GITHUB_OUTPUT"
-
   download-charts:
     uses: ./.github/workflows/tpl-download-charts.yaml
-    needs: pass-env-var-to-workflow
     with:
-      registry-source: "${{ needs.pass-env-var-to-workflow.outputs.registry-source }}"
-
+      registry-source: "https://charts.konstruct.io/"

--- a/.github/workflows/backup-charts.yaml
+++ b/.github/workflows/backup-charts.yaml
@@ -1,0 +1,20 @@
+name: "Backup Helm Charts"
+
+on:
+  push: # runs on any branch push
+  schedule:
+    - cron: "0 0 * * 1" # runs every Monday at midnight
+  workflow_dispatch: # runs whenever the workflow is dispatched via the UI
+
+env:
+  REGISTRY_SOURCE: "https://charts.konstruct.io/"
+
+permissions:
+  contents: write
+
+jobs:
+  download-charts:
+    uses: konstructio/charts-mirror/.github/workflows/tpl-download-charts.yaml@mirror-only
+    with:
+      registry-source: "${REGISTRY_SOURCE}"
+

--- a/.github/workflows/backup-charts.yaml
+++ b/.github/workflows/backup-charts.yaml
@@ -13,8 +13,20 @@ permissions:
   contents: write
 
 jobs:
+  # env context is not accessable in called workflow
+  # https://github.com/orgs/community/discussions/26671
+  # https://stackoverflow.com/questions/73305126/passing-env-variable-inputs-to-a-reusable-workflow
+  pass-env-var-to-workflow:
+    runs-on: ubuntu-latest
+    outputs:
+      registry-source: ${{ steps.step1.outputs.REGISTRY_SOURCE }}
+    steps:
+      - id: step1
+        run: echo "REGISTRY_SOURCE=${REGISTRY_SOURCE}" >> "$GITHUB_OUTPUT"
+
   download-charts:
     uses: konstructio/charts-mirror/.github/workflows/tpl-download-charts.yaml@mirror-only
+    needs: pass-env-var-to-workflow
     with:
-      registry-source: "${REGISTRY_SOURCE}"
+      registry-source: "${{ needs.pass-env-var-to-workflow.outputs.registry-source }}"
 

--- a/.github/workflows/mirror-charts.yaml
+++ b/.github/workflows/mirror-charts.yaml
@@ -27,6 +27,6 @@ jobs:
     uses: konstructio/charts-mirror/.github/workflows/tpl-mirror-charts.yaml@mirror-only
     needs: pass-env-var-to-workflow
     with:
-      registry-destination: "${{ needs.pass-env-var-to-workflow.outputs. registry-destination }}"
+      registry-destination: "${{ needs.pass-env-var-to-workflow.outputs.registry-destination }}"
 
 

--- a/.github/workflows/mirror-charts.yaml
+++ b/.github/workflows/mirror-charts.yaml
@@ -4,29 +4,11 @@ on:
   # push: # runs on any branch push
   workflow_dispatch: # runs whenever the workflow is dispatched via the UI
 
-env:
-  REGISTRY_DESTINATION: "https://charts.konstruct.io/"
-
 permissions:
   contents: write
 
 jobs:
-  # env context is not accessable in called workflow
-  # https://github.com/orgs/community/discussions/26671
-  # https://stackoverflow.com/questions/73305126/passing-env-variable-inputs-to-a-reusable-workflow
-  pass-env-var-to-workflow:
-    runs-on: ubuntu-latest
-    outputs:
-      registry-destination: ${{ steps.step1.outputs.REGISTRY_DESTINATION }}
-    steps:
-      - id: step1
-        run: echo "REGISTRY_DESTINATION=${REGISTRY_DESTINATION}" >> "$GITHUB_OUTPUT"
-
-
   mirror-charts:
     uses: ./.github/workflows/tpl-mirror-charts.yaml
-    needs: pass-env-var-to-workflow
     with:
-      registry-destination: "${{ needs.pass-env-var-to-workflow.outputs.registry-destination }}"
-
-
+      registry-destination: "https://charts.konstruct.io/"

--- a/.github/workflows/mirror-charts.yaml
+++ b/.github/workflows/mirror-charts.yaml
@@ -24,7 +24,7 @@ jobs:
 
 
   mirror-charts:
-    uses: konstructio/charts-mirror/.github/workflows/tpl-mirror-charts.yaml@mirror-only
+    uses: ./.github/workflows/tpl-mirror-charts.yaml
     needs: pass-env-var-to-workflow
     with:
       registry-destination: "${{ needs.pass-env-var-to-workflow.outputs.registry-destination }}"

--- a/.github/workflows/mirror-charts.yaml
+++ b/.github/workflows/mirror-charts.yaml
@@ -11,7 +11,22 @@ permissions:
   contents: write
 
 jobs:
+  # env context is not accessable in called workflow
+  # https://github.com/orgs/community/discussions/26671
+  # https://stackoverflow.com/questions/73305126/passing-env-variable-inputs-to-a-reusable-workflow
+  pass-env-var-to-workflow:
+    runs-on: ubuntu-latest
+    outputs:
+      registry-destination: ${{ steps.step1.outputs.REGISTRY_DESTINATION }}
+    steps:
+      - id: step1
+        run: echo "REGISTRY_DESTINATION=${REGISTRY_DESTINATION}" >> "$GITHUB_OUTPUT"
+
+
   mirror-charts:
     uses: konstructio/charts-mirror/.github/workflows/tpl-mirror-charts.yaml@mirror-only
+    needs: pass-env-var-to-workflow
     with:
-      registry-destination: "${REGISTRY_DESTINATION}"
+      registry-destination: "${{ needs.pass-env-var-to-workflow.outputs. registry-destination }}"
+
+

--- a/.github/workflows/mirror-charts.yaml
+++ b/.github/workflows/mirror-charts.yaml
@@ -12,3 +12,4 @@ jobs:
     uses: ./.github/workflows/tpl-mirror-charts.yaml
     with:
       registry-destination: "https://charts.konstruct.io/"
+    secrets: inherit

--- a/.github/workflows/mirror-charts.yaml
+++ b/.github/workflows/mirror-charts.yaml
@@ -1,101 +1,17 @@
 name: "Mirror Helm Charts"
 
 on:
-  push: # runs on any branch push
-  schedule:
-    - cron: "0 0 * * 1" # runs every Monday at midnight
+  # push: # runs on any branch push
   workflow_dispatch: # runs whenever the workflow is dispatched via the UI
 
 env:
-  REGISTRY_SOURCE: "https://charts.kubefirst.com"
-  REGISTRY_DESTINATION: "https://chartmuseum.freegitopsmagic.com"
+  REGISTRY_DESTINATION: "https://charts.konstruct.io/"
 
 permissions:
   contents: write
 
 jobs:
-  download-charts:
-    name: "Download charts to local Git repository"
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Checkout repository branch"
-        uses: actions/checkout@v2
-        with:
-          ref: "charts"
-          fetch-depth: 0
-
-      - name: "Install Helm mirror"
-        run: |
-          cd /tmp
-          wget https://github.com/konstructio/helm-mirror/releases/download/v0.5.0/helm-mirror_linux_x86_64.tar.gz
-          tar -xzf helm-mirror_linux_x86_64.tar.gz
-          install -m 755 bin/mirror /usr/local/bin/helm-mirror
-
-      - name: "Download a testing Chart"
-        if: github.ref != 'refs/heads/main'
-        run: |
-          helm-mirror "$REGISTRY_SOURCE" "$(pwd)" --chart-name=kubefirst --chart-version=2.4.13 --verbose
-
-      - name: "Download all Helm charts"
-        if: github.ref == 'refs/heads/main'
-        run: |
-          helm-mirror "$REGISTRY_SOURCE" "$(pwd)" --all-versions --verbose
-
-      - name: "Commit changes"
-        if: github.ref == 'refs/heads/main'
-        run: |
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "GitHub Actions Bot"
-          git add .
-          git commit -m "Update Helm charts" || true
-          git push origin charts
-
-  push-charts-to-museum:
-    name: "Push Helm charts to Remote museum"
-    needs: download-charts
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Checkout repository branch"
-        uses: actions/checkout@v2
-        with:
-          ref: "charts"
-          fetch-depth: 0
-
-      - name: "Install Helm cm-push"
-        run: |
-          cd /tmp
-          wget https://github.com/chartmuseum/helm-push/releases/download/v0.10.4/helm-push_0.10.4_linux_amd64.tar.gz
-          tar -xzf helm-push_0.10.4_linux_amd64.tar.gz
-          install -m 755 bin/helm-cm-push /usr/local/bin/helm-push
-
-      - name: "Install Hurl"
-        uses: gacts/install-hurl@v1
-
-      - name: "Validate Helm credentials"
-        run: |
-          export HURL_REGISTRY_DESTINATION="${REGISTRY_DESTINATION}"
-          hurl --test <<EOF
-          POST {{REGISTRY_DESTINATION}}/api/charts
-          [BasicAuth]
-          {{HELM_REPO_USERNAME}}: {{HELM_REPO_PASSWORD}}
-
-          HTTP 400
-          [Asserts]
-          jsonpath "$.error" == "EOF"
-          EOF
-        env:
-          HURL_HELM_REPO_USERNAME: "${{ secrets.TEST_CHARTMUSEUM_USER }}"
-          HURL_HELM_REPO_PASSWORD: "${{ secrets.TEST_CHARTMUSEUM_PASSWORD }}"
-
-      - name: "Upload Helm charts to a different museum"
-        if: github.ref == 'refs/heads/main'
-        run: |
-          # find each .tgz file in the current directory, then push
-          # them to a remote museum
-          for tgz in $(find . -name "*.tgz"); do
-            echo "Found Helm Chart ${tgz}"
-            helm-push "${tgz}" "${REGISTRY_DESTINATION}" --force
-          done
-        env:
-          HELM_REPO_USERNAME: "${{ secrets.TEST_CHARTMUSEUM_USER }}"
-          HELM_REPO_PASSWORD: "${{ secrets.TEST_CHARTMUSEUM_PASSWORD }}"
+  mirror-charts:
+    uses: konstructio/charts-mirror/.github/workflows/tpl-mirror-charts.yaml@mirror-only
+    with:
+      registry-destination: "${REGISTRY_DESTINATION}"

--- a/.github/workflows/tpl-download-charts.yaml
+++ b/.github/workflows/tpl-download-charts.yaml
@@ -1,0 +1,51 @@
+name: "Download Charts"
+
+on:
+  workflow_call:
+    inputs:
+      registry-source:
+        type: string
+        required: true
+        description: "Repository to pull Helm charts from"
+      target-branch:
+        type: string
+        description: "Branch to commit downloaded Helm charts"
+        default: "charts"
+
+jobs:
+  download-charts:
+    name: "Download charts to local Git repository"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout repository branch"
+        uses: actions/checkout@v2
+        with:
+          ref: "${{ inputs.target-branch }}"
+          fetch-depth: 0
+
+      - name: "Install Helm mirror"
+        run: |
+          cd /tmp
+          wget https://github.com/konstructio/helm-mirror/releases/download/v0.5.0/helm-mirror_linux_x86_64.tar.gz
+          tar -xzf helm-mirror_linux_x86_64.tar.gz
+          install -m 755 bin/mirror /usr/local/bin/helm-mirror
+          cd -
+
+      - name: "Download a testing Chart"
+        if: github.ref != 'refs/heads/main'
+        run: |
+          helm-mirror "${{ inputs.registry-source }}" "$(pwd)" --chart-name=kubefirst --chart-version=2.4.13 --verbose
+
+      - name: "Download all Helm charts"
+        if: github.ref == 'refs/heads/main'
+        run: |
+          helm-mirror "${{ inputs.registry-source }}" "$(pwd)" --all-versions --verbose
+
+      - name: "Commit changes"
+        if: github.ref == 'refs/heads/main'
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "GitHub Actions Bot"
+          git add .
+          git commit -m "Update Helm charts" || true
+          git push origin ${{ inputs.target-branch }}

--- a/.github/workflows/tpl-download-charts.yaml
+++ b/.github/workflows/tpl-download-charts.yaml
@@ -11,6 +11,10 @@ on:
         type: string
         description: "Branch to commit downloaded Helm charts"
         default: "charts"
+      helm-mirror-version:
+          type: string
+          description: "Helm Mirror version"
+          default: "v0.5.0"
 
 jobs:
   download-charts:
@@ -26,7 +30,7 @@ jobs:
       - name: "Install Helm mirror"
         run: |
           cd /tmp
-          wget https://github.com/konstructio/helm-mirror/releases/download/v0.5.0/helm-mirror_linux_x86_64.tar.gz
+          wget https://github.com/konstructio/helm-mirror/releases/download/${{ inputs.helm-mirror-version }}/helm-mirror_linux_x86_64.tar.gz
           tar -xzf helm-mirror_linux_x86_64.tar.gz
           install -m 755 bin/mirror /usr/local/bin/helm-mirror
           cd -

--- a/.github/workflows/tpl-download-charts.yaml
+++ b/.github/workflows/tpl-download-charts.yaml
@@ -39,6 +39,7 @@ jobs:
         if: github.ref != 'refs/heads/main'
         run: |
           helm-mirror "${{ inputs.registry-source }}" "$(pwd)" --chart-name=kubefirst --chart-version=2.4.13 --verbose
+          cat index.yaml
 
       - name: "Download all Helm charts"
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/tpl-mirror-charts.yaml
+++ b/.github/workflows/tpl-mirror-charts.yaml
@@ -1,0 +1,66 @@
+name: "Mirror Helm Charts"
+
+on:
+  workflow_call:
+    inputs:
+      registry-destination:
+        type: string
+        required: true
+        description: "Repository to pull Helm charts from"
+      source-branch:
+        type: string
+        description: "Branch to commit downloaded Helm charts"
+        default: "charts"
+
+permissions:
+  contents: write
+
+jobs:
+  push-charts-to-museum:
+    name: "Checkout git-store"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout repository branch"
+        uses: actions/checkout@v2
+        with:
+          ref: "${{ inputs.target-branch }}"
+          fetch-depth: 0
+
+      - name: "Install Helm cm-push"
+        run: |
+          cd /tmp
+          wget https://github.com/chartmuseum/helm-push/releases/download/v0.10.4/helm-push_0.10.4_linux_amd64.tar.gz
+          tar -xzf helm-push_0.10.4_linux_amd64.tar.gz
+          install -m 755 bin/helm-cm-push /usr/local/bin/helm-push
+
+      - name: "Install Hurl"
+        uses: gacts/install-hurl@v1
+
+      - name: "Validate Helm credentials"
+        run: |
+          export HURL_REGISTRY_DESTINATION="${{ inputs.registry-destination }}"
+          hurl --test <<EOF
+          POST "${{ inputs.registry-destination }}"/api/charts
+          [BasicAuth]
+          {{HELM_REPO_USERNAME}}: {{HELM_REPO_PASSWORD}}
+
+          HTTP 400
+          [Asserts]
+          jsonpath "$.error" == "EOF"
+          EOF
+        env:
+          HURL_HELM_REPO_USERNAME: "${{ secrets.TEST_CHARTMUSEUM_USER }}"
+          HURL_HELM_REPO_PASSWORD: "${{ secrets.TEST_CHARTMUSEUM_PASSWORD }}"
+
+      - name: "Upload Helm charts to a different museum"
+        if: github.ref == 'refs/heads/main'
+        run: |
+          # find each .tgz file in the current directory, then push
+          # them to a remote museum
+          for tgz in $(find . -name "*.tgz"); do
+            echo "Found Helm Chart ${tgz}"
+            helm-push "${tgz}" "${{ inputs.registry-destination }}" --force
+          done
+        env:
+          HELM_REPO_USERNAME: "${{ secrets.TEST_CHARTMUSEUM_USER }}"
+          HELM_REPO_PASSWORD: "${{ secrets.TEST_CHARTMUSEUM_PASSWORD }}"

--- a/.github/workflows/tpl-mirror-charts.yaml
+++ b/.github/workflows/tpl-mirror-charts.yaml
@@ -11,6 +11,10 @@ on:
         type: string
         description: "Branch to commit downloaded Helm charts"
         default: "charts"
+      helm-push-version:
+          type: string
+          description: "Chart museum helm push binary version"
+          default: "0.10.4"
 
 permissions:
   contents: write
@@ -29,8 +33,8 @@ jobs:
       - name: "Install Helm cm-push"
         run: |
           cd /tmp
-          wget https://github.com/chartmuseum/helm-push/releases/download/v0.10.4/helm-push_0.10.4_linux_amd64.tar.gz
-          tar -xzf helm-push_0.10.4_linux_amd64.tar.gz
+          wget https://github.com/chartmuseum/helm-push/releases/download/v${{ inputs.helm-push-version }}/helm-push_${{ inputs.helm-push-version }}_linux_amd64.tar.gz
+          tar -xzf helm-push_${{ inputs.helm-push-version }}_linux_amd64.tar.gz
           install -m 755 bin/helm-cm-push /usr/local/bin/helm-push
 
       - name: "Install Hurl"

--- a/.github/workflows/tpl-mirror-charts.yaml
+++ b/.github/workflows/tpl-mirror-charts.yaml
@@ -7,7 +7,7 @@ on:
         type: string
         required: true
         description: "Repository to pull Helm charts from"
-      source-branch:
+      target-branch:
         type: string
         description: "Branch to commit downloaded Helm charts"
         default: "charts"


### PR DESCRIPTION
## Description
Update workflow to only backup to chart museum. Also refactor into smaller components to allow us to separately invoke backup, mirror or both workflows.

## Related Issue(s)
None

## How to test
Manually trigger a workflow here https://github.com/konstructio/charts-mirror/actions/workflows/backup-charts.yaml (somehow disabled even though `workflow_dispatch` is set)
